### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   validation:
-    uses: microsoft/action-python/.github/workflows/validation.yml@0.7.0
+    uses: microsoft/action-python/.github/workflows/validation.yml@0.7.2
     with:
       workdir: '.'
 
   publish:
-    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.0
+    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.2
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD  }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.0
+    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.2
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD  }}

--- a/.github/workflows/schedule-update-actions.yml
+++ b/.github/workflows/schedule-update-actions.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.PAT }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.PAT }}

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_TOKEN }}

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -5,7 +5,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2 # important!
+      - uses: actions/checkout@v4.1.1 # important!
       - uses: euphoricsystems/action-sync-template-repository@v2.5.1
         with:
           github-token: ${{ secrets.SEMANTIC_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)** published a new release **[v5.4.0](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.4.0)** on 2023-11-03T09:41:15Z
* **[microsoft/action-python](https://github.com/microsoft/action-python)** published a new release **[0.7.2](https://github.com/microsoft/action-python/releases/tag/0.7.2)** on 2023-09-14T21:18:02Z
